### PR TITLE
Add project showcase and placeholder client logos

### DIFF
--- a/images/3m.svg
+++ b/images/3m.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 100">
+  <rect width="300" height="100" fill="white"/>
+  <text x="150" y="60" font-size="30" text-anchor="middle" fill="black" font-family="Arial">3M</text>
+</svg>

--- a/images/amazon.svg
+++ b/images/amazon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 100">
+  <rect width="300" height="100" fill="white"/>
+  <text x="150" y="60" font-size="40" text-anchor="middle" fill="black" font-family="Arial">Amazon</text>
+</svg>

--- a/images/fldfs.svg
+++ b/images/fldfs.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 100">
+  <rect width="300" height="100" fill="white"/>
+  <text x="150" y="60" font-size="30" text-anchor="middle" fill="black" font-family="Arial">FL-DFS</text>
+</svg>

--- a/images/hyatt.svg
+++ b/images/hyatt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 100">
+  <rect width="300" height="100" fill="white"/>
+  <text x="150" y="60" font-size="30" text-anchor="middle" fill="black" font-family="Arial">Hyatt</text>
+</svg>

--- a/images/ryder.svg
+++ b/images/ryder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 100">
+  <rect width="300" height="100" fill="white"/>
+  <text x="150" y="60" font-size="30" text-anchor="middle" fill="black" font-family="Arial">Ryder</text>
+</svg>

--- a/images/windhaven.svg
+++ b/images/windhaven.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 100">
+  <rect width="300" height="100" fill="white"/>
+  <text x="150" y="60" font-size="30" text-anchor="middle" fill="black" font-family="Arial">Windhaven</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -41,6 +41,44 @@
     <section id="projects">
       <h2>Projects</h2>
       <p>Visit my <a href="https://github.com/techlock77">GitHub profile</a> for examples of data engineering projects and infrastructure code.</p>
+      <div class="project-grid">
+        <div class="project-tile">
+          <div class="tile-inner">
+            <div class="tile-front">Smart Room Allocation Optimization</div>
+            <div class="tile-back">Smart Room Allocation Optimization</div>
+          </div>
+        </div>
+        <div class="project-tile">
+          <div class="tile-inner">
+            <div class="tile-front">Audience Sentiment Enrichment</div>
+            <div class="tile-back">Audience Sentiment Enrichment</div>
+          </div>
+        </div>
+        <div class="project-tile">
+          <div class="tile-inner">
+            <div class="tile-front">Data Architecture &amp; Modernization</div>
+            <div class="tile-back">Data Architecture &amp; Modernization</div>
+          </div>
+        </div>
+        <div class="project-tile">
+          <div class="tile-inner">
+            <div class="tile-front">ETL process Modernization</div>
+            <div class="tile-back">ETL process Modernization</div>
+          </div>
+        </div>
+        <div class="project-tile">
+          <div class="tile-inner">
+            <div class="tile-front">Data Modernization + Ring Central Implementation</div>
+            <div class="tile-back">Data Modernization + Ring Central Implementation</div>
+          </div>
+        </div>
+        <div class="project-tile">
+          <div class="tile-inner">
+            <div class="tile-front">Transactional Process Data Mart</div>
+            <div class="tile-back">Transactional Process Data Mart</div>
+          </div>
+        </div>
+      </div>
     </section>
 
     <section id="clients">
@@ -48,37 +86,37 @@
       <div class="client-grid">
         <div class="client-tile">
           <div class="tile-inner">
-            <div class="tile-front">Amazon</div>
+            <div class="tile-front"><img src="images/amazon.svg" alt="Amazon logo"></div>
             <div class="tile-back">Amazon</div>
           </div>
         </div>
         <div class="client-tile">
           <div class="tile-inner">
-            <div class="tile-front">Hyatt</div>
+            <div class="tile-front"><img src="images/hyatt.svg" alt="Hyatt logo"></div>
             <div class="tile-back">Hyatt</div>
           </div>
         </div>
         <div class="client-tile">
           <div class="tile-inner">
-            <div class="tile-front">Ryder</div>
+            <div class="tile-front"><img src="images/ryder.svg" alt="Ryder logo"></div>
             <div class="tile-back">Ryder</div>
           </div>
         </div>
         <div class="client-tile">
           <div class="tile-inner">
-            <div class="tile-front">3M</div>
+            <div class="tile-front"><img src="images/3m.svg" alt="3M logo"></div>
             <div class="tile-back">3M</div>
           </div>
         </div>
         <div class="client-tile">
           <div class="tile-inner">
-            <div class="tile-front">FL-DFS</div>
+            <div class="tile-front"><img src="images/fldfs.svg" alt="FL-DFS logo"></div>
             <div class="tile-back">FL-DFS</div>
           </div>
         </div>
         <div class="client-tile">
           <div class="tile-inner">
-            <div class="tile-front">Windhaven Insurance Company</div>
+            <div class="tile-front"><img src="images/windhaven.svg" alt="Windhaven Insurance Company logo"></div>
             <div class="tile-back">Windhaven Insurance Company</div>
           </div>
         </div>

--- a/scripts/client-tiles.js
+++ b/scripts/client-tiles.js
@@ -1,8 +1,13 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const section = document.getElementById('clients');
-  if (!section) return;
-  const tiles = section.querySelectorAll('.client-tile');
-  section.addEventListener('mouseenter', () => {
-    tiles.forEach(tile => tile.classList.add('flip'));
-  }, { once: true });
+  const setupFlip = (sectionId, tileSelector) => {
+    const section = document.getElementById(sectionId);
+    if (!section) return;
+    const tiles = section.querySelectorAll(tileSelector);
+    section.addEventListener('mouseenter', () => {
+      tiles.forEach(tile => tile.classList.add('flip'));
+    }, { once: true });
+  };
+
+  setupFlip('clients', '.client-tile');
+  setupFlip('projects', '.project-tile');
 });

--- a/styles/site.css
+++ b/styles/site.css
@@ -1,8 +1,8 @@
 :root {
-  --primary: #2563eb;
-  --secondary: #0f172a;
-  --background: #f8fafc;
-  --text: #1e293b;
+  --primary: #000;
+  --secondary: #222;
+  --background: #fff;
+  --text: #111;
 }
 
 body {
@@ -14,7 +14,7 @@ body {
 }
 
 header {
-  background: var(--primary);
+  background: linear-gradient(135deg, #000, #444);
   color: #fff;
   padding: 40px 20px;
   text-align: center;
@@ -86,20 +86,23 @@ footer {
   }
 }
 
-.client-grid {
+.client-grid,
+.project-grid {
   display: flex;
   flex-wrap: wrap;
   gap: 20px;
   justify-content: center;
 }
 
-.client-tile {
+.client-tile,
+.project-tile {
   width: 150px;
   height: 100px;
   perspective: 600px;
 }
 
-.client-tile .tile-inner {
+.client-tile .tile-inner,
+.project-tile .tile-inner {
   position: relative;
   width: 100%;
   height: 100%;
@@ -108,7 +111,9 @@ footer {
 }
 
 .client-tile .tile-front,
-.client-tile .tile-back {
+.client-tile .tile-back,
+.project-tile .tile-front,
+.project-tile .tile-back {
   position: absolute;
   top: 0;
   left: 0;
@@ -123,13 +128,18 @@ footer {
   background: #fff;
   color: var(--text);
 }
-
-.client-tile .tile-back {
+.client-tile .tile-back,
+.project-tile .tile-back {
   transform: rotateY(180deg);
   background: var(--primary);
   color: #fff;
 }
-
-.client-tile.flip .tile-inner {
+.client-tile.flip .tile-inner,
+.project-tile.flip .tile-inner {
   transform: rotateY(180deg);
+}
+
+.tile-front img {
+  max-width: 80%;
+  height: auto;
 }


### PR DESCRIPTION
## Summary
- add animated project tiles under Projects section
- include placeholder logos for each client
- switch color scheme to black/white gradient
- share flip animation between project and client tiles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845ecc3f5888320bda7d600a4080c05