### PR TITLE
Add data-themed background

### DIFF
--- a/images/data-background.svg
+++ b/images/data-background.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <rect width="200" height="200" fill="none"/>
+  <g fill="#e62b1e" transform="translate(20,20)">
+    <polygon points="15,0 30,8 15,16 0,8"/>
+    <polygon points="15,16 30,24 15,32 0,24"/>
+    <polygon points="15,32 30,40 15,48 0,40"/>
+  </g>
+  <g stroke="#56b9e9" stroke-width="3" stroke-linecap="round" fill="none" transform="translate(150,20)">
+    <line x1="-15" y1="0" x2="15" y2="0"/>
+    <line x1="0" y1="-15" x2="0" y2="15"/>
+    <line x1="-10" y1="-10" x2="10" y2="10"/>
+    <line x1="-10" y1="10" x2="10" y2="-10"/>
+  </g>
+  <g fill="#f7941d" transform="translate(20,110)">
+    <text x="0" y="15" font-family="Arial" font-size="15" fill="#f7941d">AWS</text>
+    <path d="M0 20 Q20 30 40 20" stroke="#f7941d" stroke-width="3" fill="none"/>
+    <path d="M30 17 l10 3 -10 3z" fill="#f7941d"/>
+  </g>
+  <g fill="#007fff" transform="translate(150,110)">
+    <polygon points="0,40 15,0 30,40 24,40 15,10 6,40"/>
+  </g>
+  <g fill="#673ab7" transform="translate(80,60)">
+    <ellipse cx="20" cy="5" rx="20" ry="5"/>
+    <rect x="0" y="5" width="40" height="20"/>
+    <ellipse cx="20" cy="25" rx="20" ry="5"/>
+  </g>
+</svg>

--- a/styles/site.css
+++ b/styles/site.css
@@ -11,7 +11,11 @@ body {
   margin: 0;
   line-height: 1.6;
   color: var(--text);
-  background: linear-gradient(#fff, var(--background));
+  background-color: var(--background);
+  background-image: linear-gradient(#fff, var(--background)), url('../images/data-background.svg');
+  background-repeat: no-repeat, repeat;
+  background-size: cover, 200px 200px;
+  background-attachment: scroll, fixed;
 }
 
 header {


### PR DESCRIPTION
## Summary
- add a repeating SVG background with icons for Databricks, Snowflake, AWS, Azure and data
- update CSS to apply new pattern to body background

## Testing
- `ls > /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_684d1fc928448320ad1e43fa3ed122d2